### PR TITLE
chore: bump pydantic to v2.5.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 ops
 jinja2
-pydantic<2.0
+pydantic==2.5.3
 pytest-interface-tester
 jsonschema
 cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.6.0
+    # via pydantic
 attrs==23.2.0
     # via
     #   jsonschema
@@ -36,10 +38,12 @@ pluggy==1.4.0
     # via pytest
 pycparser==2.21
     # via cffi
-pydantic==1.10.14
+pydantic==2.5.3
     # via
     #   -r requirements.in
     #   pytest-interface-tester
+pydantic-core==2.14.6
+    # via pydantic
 pytest==8.0.2
     # via pytest-interface-tester
 pytest-interface-tester==2.0.1
@@ -59,6 +63,8 @@ rpds-py==0.18.0
 typer==0.7.0
     # via pytest-interface-tester
 typing-extensions==4.10.0
-    # via pydantic
+    # via
+    #   pydantic
+    #   pydantic-core
 websocket-client==1.7.0
     # via ops


### PR DESCRIPTION
# Description

Bump pydantic to v2.5.3.

## Note

Unfortunately we can't go higher at the moment because the `rustc` package from the apt repo for Ubuntu 22.04 used in the Charm isn't compatible. You can read more about this here: https://github.com/pydantic/pydantic-core/issues/1176

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library