### PR TITLE
feat: Implement requirer side of sdcore_config interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ juju deploy self-signed-certificates
 
 juju integrate sdcore-nrf-k8s mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 juju integrate sdcore-udm-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-udm-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-udm-k8s:sdcore_config sdcore-webui-k8s:sdcore-config

--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ A Charmed Operator for SD-Core's Unified Data Manager (UDM) component for K8s.
 juju deploy mongodb-k8s --channel 6/beta --trust
 juju deploy sdcore-nrf-k8s --channel=1.5/edge
 juju deploy sdcore-udm-k8s --channel=1.5/edge
+juju deploy sdcore-webui-k8s --channel=1.5/edge
+juju integrate sdcore-webui-k8s:common_database mongodb-k8s:database
+juju integrate sdcore-webui-k8s:auth_database mongodb-k8s:database
 juju deploy self-signed-certificates
 
 juju integrate sdcore-nrf-k8s mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-udm-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-udm-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-udm-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 ```
 
 ## Get the Home Network Public Key

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -40,7 +40,9 @@ requires:
   certificates:
     interface: tls-certificates
   logging:
-      interface: loki_push_api
+    interface: loki_push_api
+  sdcore_config:
+    interface: sdcore_config
 
 assumes:
   - k8s-api

--- a/lib/charms/sdcore_webui_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_webui_k8s/v0/sdcore_config.py
@@ -1,0 +1,339 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Library for the `sdcore_config` relation.
+
+This library contains the Requires and Provides classes for handling the `sdcore_config`
+interface.
+
+The purpose of this library is to relate charms claiming
+to be able to provide or consume the information to access the webui GRPC address
+for configuration purposes in SD-Core.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.sdcore_webui_k8s.v0.sdcore_config
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+### Requirer charm
+The requirer charm is the one requiring the Webui information.
+
+Example:
+```python
+
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.sdcore_webui_k8s.v0.sdcore_config import (
+    SdcoreConfigRequires,
+    WebuiBroken,
+    WebuiUrlAvailable,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DummySdcoreConfigRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.webui_requirer = SdcoreConfigRequires(
+            self, "sdcore_config"
+        )
+        self.framework.observe(
+            self.webui_requirer.on.webui_url_available,
+            self._on_webui_url_available
+        )
+        self.framework.observe(self.webui_requirer.on.webui_broken, self._on_webui_broken)
+
+    def _on_webui_url_available(self, event: WebuiUrlAvailable):
+        logging.info(f"Webui URL from the event: {event.webui_url}")
+        logging.info(f"Webui URL from the property: {self.webui_requirer.webui_url}")
+
+    def _on_webui_broken(self, event: WebuiBroken) -> None:
+        logging.info(f"Received {event}")
+
+
+if __name__ == "__main__":
+    main(DummySdcoreConfigRequirerCharm)
+```
+
+### Provider charm
+The provider charm is the one providing the information about the Webui.
+
+Example:
+```python
+
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.sdcore_webui_k8s.v0.sdcore_config import SdcoreConfigProvides
+
+
+class DummySdcoreConfigProviderCharm(CharmBase):
+
+    WEBUI_URL = "sdcore-webui-k8s:9876"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.webui_url_provider = SdcoreConfigProvides(self, "sdcore_config")
+        self.framework.observe(
+            self.on.sdcore_config_relation_joined, self._on_sdcore_config_relation_joined
+        )
+
+    def _on_sdcore_config_relation_joined(self, event: RelationJoinedEvent):
+        relation_id = event.relation.id
+        self.webui_url_provider.set_webui_url(
+            webui_url=self.WEBUI_URL,
+            relation_id=relation_id,
+        )
+
+
+if __name__ == "__main__":
+    main(DummySdcoreConfigProviderCharm)
+```
+
+"""
+import logging
+from typing import Optional
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.model import Relation
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e2f454cc121f449bbaa8fb0fd5a9867b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `sdcore_config` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "webui_url": "sdcore-webui-k8s:9876",
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class SdcoreConfigProviderAppData(BaseModel):
+    """Provider application data for sdcore_config."""
+    webui_url: str = Field(
+        description="GRPC address of the Webui including Webui hostname and a fixed GRPC port.",
+        examples=["sdcore-webui-k8s:9876"]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of the sdcore-config interface."""
+    app: SdcoreConfigProviderAppData
+
+
+def data_is_valid(data: dict) -> bool:
+    """Return whether data is valid.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data is valid, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class WebuiUrlAvailable(EventBase):
+    """Charm event emitted when the Webui URL is available."""
+
+    def __init__(self, handle: Handle, webui_url: str):
+        """Init."""
+        super().__init__(handle)
+        self.webui_url = webui_url
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "webui_url": self.webui_url,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restore snapshot."""
+        self.webui_url = snapshot["webui_url"]
+
+
+class WebuiBroken(EventBase):
+    """Charm event emitted when the Webui goes down."""
+
+    def __init__(self, handle: Handle):
+        """Init."""
+        super().__init__(handle)
+
+
+class SdcoreConfigRequirerCharmEvents(CharmEvents):
+    """List of events that the SD-Core config requirer charm can leverage."""
+
+    webui_url_available = EventSource(WebuiUrlAvailable)
+    webui_broken = EventSource(WebuiBroken)
+
+
+class SdcoreConfigRequires(Object):
+    """Class to be instantiated by the SD-Core config requirer charm."""
+
+    on = SdcoreConfigRequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handle relation changed event.
+
+        Args:
+            event (RelationChangedEvent): Juju event.
+
+        Returns:
+            None
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data(event.relation):
+            self.on.webui_url_available.emit(
+                webui_url=remote_app_relation_data,
+            )
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle the Sdcore config relation broken event.
+
+        Args:
+            event (RelationBrokenEvent): Juju event.
+        """
+        self.on.webui_broken.emit()
+
+    @property
+    def webui_url(self) -> Optional[str]:
+        """Return the address of the webui GRPC endpoint.
+
+        Returns:
+            str: Endpoint address.
+        """
+        return self._get_remote_app_relation_data()
+
+    def _get_remote_app_relation_data(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[str]:
+        """Get relation data for the remote application.
+
+        Args:
+            relation: Juju relation object (optional).
+
+        Returns:
+        str: Relation data for the remote application
+            or None if the relation data is invalid.
+        """
+        relation = relation or self.model.get_relation(self.relation_name)
+
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+
+        remote_app_relation_data = dict(relation.data[relation.app])
+
+        if not data_is_valid(remote_app_relation_data):
+            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            return None
+
+        return remote_app_relation_data["webui_url"]
+
+
+class SdcoreConfigProvides(Object):
+    """Class to be instantiated by the charm providing the SD-Core Webui URL."""
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.charm = charm
+
+    def set_webui_url(self, webui_url: str, relation_id: int) -> None:
+        """Set the address of the Webui GRPC endpoint.
+
+        Args:
+            webui_url (str): Webui GRPC service address.
+            relation_id (int): Relation ID.
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+
+        if not data_is_valid(data={"webui_url": webui_url}):
+            raise ValueError(f"Invalid url: {webui_url}")
+
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        if relation not in self.model.relations[self.relation_name]:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        relation.data[self.charm.app].update({"webui_url": webui_url})
+
+    def set_webui_url_in_all_relations(self, webui_url: str) -> None:
+        """Set Webui URL in applications for all applications.
+
+        Args:
+            webui_url (str): Webui GRPC service address
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+
+        if not data_is_valid(data={"webui_url": webui_url}):
+            raise ValueError(f"Invalid url: {webui_url}")
+
+        relations = self.model.relations[self.relation_name]
+
+        if not relations:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        for relation in relations:
+            relation.data[self.charm.app].update({"webui_url": webui_url})

--- a/src/templates/udmcfg.yaml.j2
+++ b/src/templates/udmcfg.yaml.j2
@@ -2,6 +2,7 @@ configuration:
   keys:
     udmProfileAHNPrivateKey: {{ _home_network_private_key }}
   nrfUri: {{ nrf_url }}
+  webuiUri: {{ webui_uri }}
   sbi:
     bindingIPv4: 0.0.0.0
     port: {{ udm_sbi_port }}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -22,3 +22,8 @@ output "logging_endpoint" {
   description = "Name of the endpoint used to integrate with the Logging provider."
   value       = "logging"
 }
+
+output "sdcore_config_endpoint" {
+  description = "Name of the endpoint used to integrate with the Webui."
+  value       = "sdcore_config"
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -25,6 +25,9 @@ TLS_PROVIDER_APP_NAME = "self-signed-certificates"
 TLS_PROVIDER_APP_CHANNEL = "latest/stable"
 GRAFANA_AGENT_APP_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_APP_CHANNEL = "latest/stable"
+WEBUI_CHARM_NAME = "sdcore-webui-k8s"
+WEBUI_CHARM_CHANNEL = "1.5/edge"
+TIMEOUT = 1000
 
 
 async def _deploy_database(ops_test: OpsTest):
@@ -38,19 +41,22 @@ async def _deploy_database(ops_test: OpsTest):
     )
 
 
-async def _deploy_and_integrate_nrf_and_mongodb(ops_test: OpsTest):
-    assert ops_test.model
-    await _deploy_database(ops_test)
-    await _deploy_nrf(ops_test)
-    await ops_test.model.integrate(relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME)
-
-
 async def _deploy_nrf(ops_test: OpsTest):
     assert ops_test.model
     await ops_test.model.deploy(
         NRF_APP_NAME,
         application_name=NRF_APP_NAME,
         channel=NRF_APP_CHANNEL,
+        trust=True,
+    )
+
+
+async def _deploy_webui(ops_test: OpsTest):
+    assert ops_test.model
+    await ops_test.model.deploy(
+        WEBUI_CHARM_NAME,
+        application_name=WEBUI_CHARM_NAME,
+        channel=WEBUI_CHARM_CHANNEL,
     )
 
 
@@ -75,18 +81,28 @@ async def _deploy_tls_provider(ops_test: OpsTest):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def deploy(ops_test: OpsTest, request):
     """Deploy necessary components."""
     assert ops_test.model
-    deploy_nrf = asyncio.create_task(_deploy_and_integrate_nrf_and_mongodb(ops_test))
+    deploy_database = asyncio.create_task(_deploy_database(ops_test))
+    deploy_nrf = asyncio.create_task(_deploy_nrf(ops_test))
     deploy_tls = asyncio.create_task(_deploy_tls_provider(ops_test))
     deploy_grafana_agent = asyncio.create_task(_deploy_grafana_agent(ops_test))
+    deploy_webui = asyncio.create_task(_deploy_webui(ops_test))
     charm = Path(request.config.getoption("--charm_path")).resolve()
-    await deploy_nrf
+    await deploy_database
     await deploy_tls
+    await deploy_nrf
     await deploy_grafana_agent
+    await deploy_webui
     await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME)
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DATABASE_APP_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
+    )
     resources = {
         "udm-image": METADATA["resources"]["udm-image"]["upstream-source"],
     }
@@ -106,7 +122,7 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
     await ops_test.model.wait_for_idle(
         apps=[APPLICATION_NAME],
         status="blocked",
-        timeout=1000,
+        timeout=TIMEOUT,
     )
 
 
@@ -118,12 +134,16 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     )
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_APP_NAME)
     await ops_test.model.integrate(
+        relation1=f"{APPLICATION_NAME}:sdcore_config",
+        relation2=f"{WEBUI_CHARM_NAME}:sdcore-config",
+    )
+    await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:logging", relation2=GRAFANA_AGENT_APP_NAME
     )
     await ops_test.model.wait_for_idle(
         apps=[APPLICATION_NAME],
         status="active",
-        timeout=1000,
+        timeout=TIMEOUT,
     )
 
 
@@ -138,12 +158,10 @@ async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, deploy)
 async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
     await _deploy_nrf(ops_test)
-    await ops_test.model.integrate(
-        relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
-    )
     await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)
-    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=TIMEOUT)
 
 
 @pytest.mark.abort_on_fail
@@ -158,7 +176,31 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_tls_provider(ops_test)
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_APP_NAME)
-    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=TIMEOUT)
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_webui_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(WEBUI_CHARM_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_webui_and_wait_for_active_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await _deploy_webui(ops_test)
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DATABASE_APP_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=f"{APPLICATION_NAME}:sdcore_config",
+        relation2=f"{WEBUI_CHARM_NAME}:sdcore-config",
+    )
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=TIMEOUT)
 
 
 @pytest.mark.abort_on_fail
@@ -169,7 +211,7 @@ async def test_when_scale_app_beyond_1_then_only_one_unit_is_active(
     assert isinstance(app := ops_test.model.applications[APPLICATION_NAME], Application)
     await app.scale(3)
     await ops_test.model.wait_for_idle(
-        apps=[APPLICATION_NAME], timeout=1000, wait_for_at_least_units=3
+        apps=[APPLICATION_NAME], timeout=TIMEOUT, wait_for_at_least_units=3
     )
     unit_statuses = Counter(unit.workload_status for unit in app.units)
     assert unit_statuses.get("active") == 1

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -103,6 +103,7 @@ async def deploy(ops_test: OpsTest, request):
     await ops_test.model.integrate(
         relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
     )
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=WEBUI_CHARM_NAME)
     resources = {
         "udm-image": METADATA["resources"]["udm-image"]["upstream-source"],
     }
@@ -159,6 +160,7 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_nrf(ops_test)
     await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=WEBUI_CHARM_NAME)
     await ops_test.model.integrate(relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=TIMEOUT)

--- a/tests/unit/expected_udmcfg.yaml
+++ b/tests/unit/expected_udmcfg.yaml
@@ -2,6 +2,7 @@ configuration:
   keys:
     udmProfileAHNPrivateKey: whatever home network key
   nrfUri: https://nrf:443
+  webuiUri: sdcore-webui:9876
   sbi:
     bindingIPv4: 0.0.0.0
     port: 29503


### PR DESCRIPTION
# Description

- Implement requirer side of sdcore_config interface
- Place _configure_sdcore_udm after charm constructor

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library