### PR TITLE
fix: sdcore_config interface tests

### DIFF
--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,40 @@
+import tempfile
+
+import pytest
+import scenario
+from charm import UDMOperatorCharm
+from interface_tester import InterfaceTester
+from ops.pebble import Layer, ServiceStatus
+
+
+@pytest.fixture
+def interface_tester(interface_tester: InterfaceTester):
+    with tempfile.TemporaryDirectory() as tempdir:
+        config_mount = scenario.Mount(
+            location="/etc/udm/",
+            src=tempdir,
+        )
+        certs_mount = scenario.Mount(
+            location="/support/TLS/",
+            src=tempdir,
+        )
+        container = scenario.Container(
+            name="udm",
+            can_connect=True,
+            layers={"udm": Layer({"services": {"udm": {}}})},
+            service_status={
+                "udm": ServiceStatus.ACTIVE,
+            },
+            mounts={
+                "config": config_mount,
+                "certs": certs_mount,
+            },
+        )
+        interface_tester.configure(
+            charm_type=UDMOperatorCharm,
+            state_template=scenario.State(
+                leader=True,
+                containers=[container],
+            ),
+        )
+        yield interface_tester

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,10 @@ envlist = fmt, lint, static, unit
 
 [vars]
 src_path = {toxinidir}/src/
+interface_test_path = {toxinidir}/tests/interface/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
+all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]interface_test_path}
 
 [testenv]
 setenv =


### PR DESCRIPTION
# Description

`sdcore-config` interface tests in https://github.com/canonical/charm-relation-interfaces are failing.
This PR adds a fixture of the UDM operator that will be used during `sdcore-config` provider tests

https://github.com/canonical/charm-relation-interfaces/actions/runs/10444868384/job/28919962915
https://juju.is/docs/sdk/write-interface-tests


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library