### PR TITLE
fix: remove free5gc prefix from configuration template

### DIFF
--- a/src/templates/udmcfg.yaml.j2
+++ b/src/templates/udmcfg.yaml.j2
@@ -9,9 +9,8 @@ configuration:
     registerIPv4: {{ pod_ip }}
     scheme: {{ scheme }}
     tls:
-      key: free5gc/support/TLS/udm.key
-      log: free5gc/udmsslkey.log
-      pem: free5gc/support/TLS/udm.pem
+      key: /support/TLS/udm.key
+      pem: /support/TLS/udm.pem
   serviceNameList:
   - nudm-sdm
   - nudm-uecm

--- a/tests/unit/expected_udmcfg.yaml
+++ b/tests/unit/expected_udmcfg.yaml
@@ -9,9 +9,8 @@ configuration:
     registerIPv4: 1.1.1.1
     scheme: https
     tls:
-      key: free5gc/support/TLS/udm.key
-      log: free5gc/udmsslkey.log
-      pem: free5gc/support/TLS/udm.pem
+      key: /support/TLS/udm.key
+      pem: /support/TLS/udm.pem
   serviceNameList:
   - nudm-sdm
   - nudm-uecm


### PR DESCRIPTION
# Description

This PR aims to fix an issue for which TLS path is not correctly handled after upstream modification https://github.com/omec-project/udm/pull/127. If the absolute path is specified, the prefix `free5gc` should not be used.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library