### PR TITLE
fix: rename configuration attribute which is renamed in the upstream

### DIFF
--- a/src/templates/udmcfg.yaml.j2
+++ b/src/templates/udmcfg.yaml.j2
@@ -13,7 +13,7 @@ configuration:
       pem: /support/TLS/udm.pem
   enableNrfCaching: true
   nrfCacheEvictionInterval: 900
-  serviceNameList:
+  serviceList:
   - nudm-sdm
   - nudm-uecm
   - nudm-ueau

--- a/tests/unit/expected_udmcfg.yaml
+++ b/tests/unit/expected_udmcfg.yaml
@@ -13,7 +13,7 @@ configuration:
       pem: /support/TLS/udm.pem
   enableNrfCaching: true
   nrfCacheEvictionInterval: 900
-  serviceNameList:
+  serviceList:
   - nudm-sdm
   - nudm-uecm
   - nudm-ueau


### PR DESCRIPTION
# Description

Gabried requested to change the one of the config attributes to standardize it for all NFs. Hence serviceNameList is changed to serviceList. This solves the simulation error in our sdcore-tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library