### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest
 pytest-asyncio==0.21.2
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,25 +12,29 @@ cachetools==5.5.0
     # via google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-durationpy==0.7
+durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
@@ -39,17 +43,23 @@ google-auth==2.35.0
 hvac==2.3.0
     # via juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via
     #   -r test-requirements.in
@@ -59,7 +69,9 @@ kubernetes==31.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
@@ -70,12 +82,9 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
@@ -85,7 +94,9 @@ parso==0.8.4
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
@@ -102,7 +113,9 @@ pyasn1==0.6.1
 pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -116,10 +129,11 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -135,10 +149,9 @@ pytz==2024.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -150,7 +163,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.8
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -169,6 +182,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
@@ -181,7 +195,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
     # via juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import UDMOperatorCharm
 
@@ -43,6 +43,6 @@ class UDMUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=UDMOperatorCharm,
         )

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import UDMUnitTestFixtures
 
@@ -14,18 +14,18 @@ class TestCharmCertificatesRelationBroken(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
@@ -38,7 +38,7 @@ class TestCharmCertificatesRelationBroken(UDMUnitTestFixtures):
             with open(f"{tempdir}/udm.key", "w") as f:
                 f.write("private key")
 
-            state_in = scenario.State(
+            state_in = testing.State(
                 relations=[certificates_relation],
                 containers=[container],
                 leader=True,

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -4,7 +4,7 @@
 
 import tempfile
 
-import scenario
+from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer, ServiceStatus
 
@@ -14,7 +14,7 @@ from tests.unit.fixtures import UDMUnitTestFixtures
 
 class TestCharmCollectStatus(UDMUnitTestFixtures):
     def test_given_not_leader_when_collect_unit_status_then_status_is_blocked(self):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
         )
 
@@ -23,10 +23,10 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         assert state_out.unit_status == BlockedStatus("Scaling is not implemented for this charm")
 
     def test_given_container_not_ready_when_collect_unit_status_then_status_is_waiting(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -36,11 +36,11 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         assert state_out.unit_status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_relations_not_created_when_collect_unit_status_then_status_is_blocked(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -54,15 +54,15 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
     def test_given_nms_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation],
             leader=True,
@@ -77,23 +77,23 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
     def test_given_nrf_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, nms_relation, nrf_relation],
             leader=True,
@@ -108,23 +108,23 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
     def test_given_webui_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, nms_relation, nrf_relation],
             leader=True,
@@ -139,23 +139,23 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
     def test_given_storage_not_attached_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, nrf_relation, nms_relation],
             leader=True,
@@ -171,32 +171,32 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -215,32 +215,32 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -259,32 +259,32 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -306,32 +306,32 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -354,34 +354,34 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
                 layers={"udm": Layer({"services": {"udm": {}}})},
                 service_statuses={"udm": ServiceStatus.ACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -404,21 +404,21 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm", can_connect=True, mounts={"workload-version": workload_version_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[nrf_relation, certificates_relation, sdcore_config_relation],
@@ -432,24 +432,24 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
             expected_version = "1.2.3"
             with open(f"{tempdir}/workload-version", "w") as f:
                 f.write(expected_version)
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm", can_connect=True, mounts={"workload-version": workload_version_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[nrf_relation, certificates_relation, sdcore_config_relation],

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -5,7 +5,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.certificates_helpers import example_cert_and_key
@@ -17,36 +17,36 @@ class TestCharmConfigure(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm//",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
             self.mock_nrf_url.return_value = "https://nrf:443"
             self.mock_sdcore_config_webui_url.return_value = "sdcore-webui:9876"
@@ -71,36 +71,36 @@ class TestCharmConfigure(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm//",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
             self.mock_nrf_url.return_value = "https://nrf:443"
             self.mock_sdcore_config_webui_url.return_value = "sdcore-webui:9876"
@@ -131,32 +131,32 @@ class TestCharmConfigure(UDMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm//",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,

--- a/tests/unit/test_charm_get_home_network_public_key_action.py
+++ b/tests/unit/test_charm_get_home_network_public_key_action.py
@@ -4,7 +4,7 @@
 import tempfile
 
 import pytest
-import scenario
+from ops import testing
 from ops.testing import ActionFailed
 
 from tests.unit.fixtures import UDMUnitTestFixtures
@@ -12,11 +12,11 @@ from tests.unit.fixtures import UDMUnitTestFixtures
 
 class TestCharmGetHomeNetworkPublicKeyAction(UDMUnitTestFixtures):
     def test_given_cant_connect_when_get_home_network_public_key_action_then_event_fails(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="udm",
             can_connect=False,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )
@@ -28,16 +28,16 @@ class TestCharmGetHomeNetworkPublicKeyAction(UDMUnitTestFixtures):
 
     def test_given_key_not_stored_when_get_home_network_public_key_action_then_event_fails(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
             )
@@ -49,16 +49,16 @@ class TestCharmGetHomeNetworkPublicKeyAction(UDMUnitTestFixtures):
 
     def test_given_stored_when_get_home_network_public_key_action_then_key_returned(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/udm/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="udm",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
             )


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use ops.testing instead of scenario. Both have the same API.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library