### PR TITLE
chore: replace ops.main.main() with ops.main

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -26,10 +26,9 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from jinja2 import Environment, FileSystemLoader
-from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, ModelError, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, ModelError, WaitingStatus, main
 from ops.charm import ActionEvent, CharmBase
 from ops.framework import EventBase
-from ops.main import main
 from ops.pebble import Layer
 
 from key_gen_utils import generate_x25519_private_key


### PR DESCRIPTION
# Description

`ops.main.main()` is deprecated. Here, we replace it with `ops.main()`.

## Logs

```
/var/lib/juju/agents/unit-gnbsim-0/charm/./src/charm.py:510: DeprecationWarning: Calling ops.main.main() is deprecated, call ops.main() instead
  main(GNBSIMOperatorCharm)
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library