### PR TITLE
fix: refresh Prometheus scrape endpoint after IP change

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -73,6 +73,7 @@ class UDMOperatorCharm(CharmBase):
         )
         self._udm_metrics_endpoint = MetricsEndpointProvider(
             self,
+            refresh_event=[self.on.update_status],
             jobs=[
                 {
                     "static_configs": [{"targets": [f"*:{PROMETHEUS_PORT}"]}],


### PR DESCRIPTION
# Description

This PR aims to fix an issue for which the unit address in the `prometheus_scrape` databag is not updated after IP change (e.g., pod restart).
The fix involves adding the `update-status` event to the list of bound events observed to re-set scrape job data.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library