### PR TITLE
feat: add NMS integration with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ juju deploy mongodb-k8s --channel 6/beta --trust
 juju deploy sdcore-nrf-k8s --channel=1.5/edge
 juju deploy sdcore-udm-k8s --channel=1.5/edge
 juju deploy sdcore-nms-k8s --channel=1.5/edge
-juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database
-juju integrate sdcore-nms-k8s:auth_database mongodb-k8s:database
 juju deploy self-signed-certificates
 
+juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database
+juju integrate sdcore-nms-k8s:auth_database mongodb-k8s:database
+juju integrate sdcore-nms-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:sdcore_config sdcore-nms-k8s:sdcore_config

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 
-import asyncio
 import logging
 from collections import Counter
 from pathlib import Path

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -49,6 +49,9 @@ async def _deploy_nrf(ops_test: OpsTest):
         channel=NRF_APP_CHANNEL,
         trust=True,
     )
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=NMS_CHARM_NAME)
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=DATABASE_APP_NAME)
 
 
 async def _deploy_nms(ops_test: OpsTest):
@@ -58,6 +61,13 @@ async def _deploy_nms(ops_test: OpsTest):
         application_name=NMS_CHARM_NAME,
         channel=NMS_CHARM_CHANNEL,
     )
+    await ops_test.model.integrate(
+        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.integrate(
+        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_PROVIDER_APP_NAME)
 
 
 async def _deploy_grafana_agent(ops_test: OpsTest):
@@ -84,26 +94,7 @@ async def _deploy_tls_provider(ops_test: OpsTest):
 async def deploy(ops_test: OpsTest, request):
     """Deploy necessary components."""
     assert ops_test.model
-    deploy_database = asyncio.create_task(_deploy_database(ops_test))
-    deploy_nrf = asyncio.create_task(_deploy_nrf(ops_test))
-    deploy_tls = asyncio.create_task(_deploy_tls_provider(ops_test))
-    deploy_grafana_agent = asyncio.create_task(_deploy_grafana_agent(ops_test))
-    deploy_nms = asyncio.create_task(_deploy_nms(ops_test))
     charm = Path(request.config.getoption("--charm_path")).resolve()
-    await deploy_database
-    await deploy_tls
-    await deploy_nrf
-    await deploy_grafana_agent
-    await deploy_nms
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
-    await ops_test.model.integrate(relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME)
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=NMS_CHARM_NAME)
     resources = {
         "udm-image": METADATA["resources"]["udm-image"]["upstream-source"],
     }
@@ -113,6 +104,11 @@ async def deploy(ops_test: OpsTest, request):
         application_name=APPLICATION_NAME,
         trust=True,
     )
+    await _deploy_database(ops_test)
+    await _deploy_tls_provider(ops_test)
+    await _deploy_grafana_agent(ops_test)
+    await _deploy_nms(ops_test)
+    await _deploy_nrf(ops_test)
 
 
 @pytest.mark.abort_on_fail
@@ -164,9 +160,6 @@ async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, deploy)
 async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
     await _deploy_nrf(ops_test)
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
-    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=NMS_CHARM_NAME)
-    await ops_test.model.integrate(relation1=DATABASE_APP_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=TIMEOUT)
 
@@ -183,6 +176,8 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_tls_provider(ops_test)
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=TIMEOUT)
 
 
@@ -197,12 +192,6 @@ async def test_remove_nms_and_wait_for_blocked_status(ops_test: OpsTest, deploy)
 async def test_restore_nms_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
     await _deploy_nms(ops_test)
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DATABASE_APP_NAME}"
-    )
     await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:sdcore_config",
         relation2=f"{NMS_CHARM_NAME}:sdcore_config",


### PR DESCRIPTION
# Description

This PR adds the NMS integration with the TLS to the integration tests.
TLS certificates integration is mandatory for NMS and the NMS charm does not share the webui address until this relation exists

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library