### PR TITLE
chore: bump udm rock to v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ juju run sdcore-udm-k8s/leader get-home-network-public-key
 
 ## Image
 
-**udm**: `ghcr.io/canonical/sdcore-udm:1.5.1`
+**udm**: `ghcr.io/canonical/sdcore-udm:1.6.1`
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,7 +24,7 @@ resources:
   udm-image:
     type: oci-image
     description: OCI image for SD-Core's UDM
-    upstream-source: ghcr.io/canonical/sdcore-udm:1.5.1
+    upstream-source: ghcr.io/canonical/sdcore-udm:1.6.1
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -635,7 +635,7 @@ class UDMOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/bin/udm --udmcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+                        "command": f"/bin/udm --cfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     },
                 },

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -182,7 +182,7 @@ class TestCharmConfigure(UDMUnitTestFixtures):
                             "udm": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/udm --udmcfg /etc/udm/udmcfg.yaml",
+                                "command": "/bin/udm --cfg /etc/udm/udmcfg.yaml",
                                 "environment": {
                                     "POD_IP": "1.1.1.1",
                                     "MANAGED_BY_CONFIG_POD": "true",


### PR DESCRIPTION
# Description

Bump the charm's rock/workload version to v1.6.1. We also make the necessary change for our charm to keep on working: we replace the existing `udmcfg` startup CLI command with the new `cfg`. 

## Reference
- https://github.com/omec-project/udm/releases/tag/v1.6.1

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library