### PR TITLE
chore: parametrize path to tls certificates

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,9 +16,9 @@ containers:
     resource: udm-image
     mounts:
       - storage: config
-        location: /etc/udm/
+        location: /sdcore/config
       - storage: certs
-        location: /support/TLS
+        location: /sdcore/certs
 
 resources:
   udm-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,14 +36,14 @@ from key_gen_utils import generate_x25519_private_key
 logger = logging.getLogger(__name__)
 
 PROMETHEUS_PORT = 8080
-BASE_CONFIG_PATH = "/etc/udm"
+BASE_CONFIG_PATH = "/sdcore/config"
 CONFIG_FILE_NAME = "udmcfg.yaml"
 UDM_SBI_PORT = 29503
 NRF_RELATION_NAME = "fiveg_nrf"
 TLS_RELATION_NAME = "certificates"
 HOME_NETWORK_KEY_NAME = "home_network.key"
-HOME_NETWORK_KEY_PATH = f"/etc/udm/{HOME_NETWORK_KEY_NAME}"
-CERTS_DIR_PATH = "/support/TLS"  # Certificate paths are hardcoded in UDM code
+HOME_NETWORK_KEY_PATH = f"/sdcore/config/{HOME_NETWORK_KEY_NAME}"
+CERTS_DIR_PATH = "/sdcore/certs"
 PRIVATE_KEY_NAME = "udm.key"
 CERTIFICATE_NAME = "udm.pem"
 CERTIFICATE_COMMON_NAME = "udm.sdcore"
@@ -363,6 +363,8 @@ class UDMOperatorCharm(CharmBase):
             udm_sbi_port=UDM_SBI_PORT,
             pod_ip=pod_ip,
             scheme="https",
+            tls_pem=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}",
+            tls_key=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             _home_network_private_key=self._get_home_network_private_key(),
             webui_uri=self._webui_requires.webui_url,
             log_level=log_level,
@@ -519,6 +521,8 @@ class UDMOperatorCharm(CharmBase):
         scheme: str,
         _home_network_private_key: str,
         webui_uri: str,
+        tls_pem: str,
+        tls_key: str,
         log_level: str,
     ) -> str:
         """Render the config file content.
@@ -529,6 +533,8 @@ class UDMOperatorCharm(CharmBase):
             pod_ip (str): UDM pod IPv4.
             scheme (str): SBI interface scheme ("http" or "https")
             webui_uri (str) : URL of the Webui
+            tls_pem (str): Path to the TLS certificate.
+            tls_key (str): Path to the TLS private key.
             log_level (str): Log level for the AMF.
 
         Returns:
@@ -543,6 +549,8 @@ class UDMOperatorCharm(CharmBase):
             scheme=scheme,
             _home_network_private_key=_home_network_private_key,
             webui_uri=webui_uri,
+            tls_pem=tls_pem,
+            tls_key=tls_key,
             log_level=log_level,
         )
 

--- a/src/templates/udmcfg.yaml.j2
+++ b/src/templates/udmcfg.yaml.j2
@@ -9,8 +9,8 @@ configuration:
     registerIPv4: {{ pod_ip }}
     scheme: {{ scheme }}
     tls:
-      key: /support/TLS/udm.key
-      pem: /support/TLS/udm.pem
+      key: {{ tls_key }}
+      pem: {{ tls_pem }}
   enableNrfCaching: true
   nrfCacheEvictionInterval: 900
   serviceList:

--- a/tests/unit/expected_udmcfg.yaml
+++ b/tests/unit/expected_udmcfg.yaml
@@ -9,8 +9,8 @@ configuration:
     registerIPv4: 1.1.1.1
     scheme: https
     tls:
-      key: /support/TLS/udm.key
-      pem: /support/TLS/udm.pem
+      key: /sdcore/certs/udm.key
+      pem: /sdcore/certs/udm.pem
   enableNrfCaching: true
   nrfCacheEvictionInterval: 900
   serviceList:

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -18,11 +18,11 @@ class TestCharmCertificatesRelationBroken(UDMUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=tempdir,
             )
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=tempdir,
             )
             container = testing.Container(
@@ -30,8 +30,8 @@ class TestCharmCertificatesRelationBroken(UDMUnitTestFixtures):
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            os.mkdir(f"{tempdir}/support")
-            os.mkdir(f"{tempdir}/support/TLS")
+            os.mkdir(f"{tempdir}/sdcore")
+            os.mkdir(f"{tempdir}/sdcore/certs")
             with open(f"{tempdir}/udm.pem", "w") as f:
                 f.write("certificate")
 

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -200,11 +200,11 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -244,11 +244,11 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -288,11 +288,11 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -335,11 +335,11 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -383,11 +383,11 @@ class TestCharmCollectStatus(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -30,11 +30,11 @@ class TestCharmConfigure(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm//",
+                location="/sdcore/config//",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -84,11 +84,11 @@ class TestCharmConfigure(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm//",
+                location="/sdcore/config//",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -144,11 +144,11 @@ class TestCharmConfigure(UDMUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/udm//",
+                location="/sdcore/config//",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -182,7 +182,7 @@ class TestCharmConfigure(UDMUnitTestFixtures):
                             "udm": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/udm --cfg /etc/udm/udmcfg.yaml",
+                                "command": "/bin/udm --cfg /sdcore/config/udmcfg.yaml",
                                 "environment": {
                                     "POD_IP": "1.1.1.1",
                                     "MANAGED_BY_CONFIG_POD": "true",

--- a/tests/unit/test_charm_get_home_network_public_key_action.py
+++ b/tests/unit/test_charm_get_home_network_public_key_action.py
@@ -29,7 +29,7 @@ class TestCharmGetHomeNetworkPublicKeyAction(UDMUnitTestFixtures):
     def test_given_key_not_stored_when_get_home_network_public_key_action_then_event_fails(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -50,7 +50,7 @@ class TestCharmGetHomeNetworkPublicKeyAction(UDMUnitTestFixtures):
     def test_given_stored_when_get_home_network_public_key_action_then_key_returned(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             config_mount = testing.Mount(
-                location="/etc/udm/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             container = testing.Container(


### PR DESCRIPTION
# Description

Now that it is possible to provide custom paths to TLS certificates in the UDM workload, we adapt our charm to provide the TLS path based on the charmcraft storage mount. We leverage this opportunity to use better paths to store this information.
 
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library